### PR TITLE
Fix crash on launch due to using deprecated addLayer for sand filter block

### DIFF
--- a/src/main/java/dev/ghen/thirst/compat/create/CreateRegistry.java
+++ b/src/main/java/dev/ghen/thirst/compat/create/CreateRegistry.java
@@ -1,19 +1,13 @@
 package dev.ghen.thirst.compat.create;
 
-import com.simibubi.create.AllBlocks;
-import com.simibubi.create.AllTileEntities;
 import com.simibubi.create.Create;
 import com.simibubi.create.content.contraptions.components.AssemblyOperatorBlockItem;
-import com.simibubi.create.content.contraptions.fluids.actors.SpoutBlock;
-import com.simibubi.create.content.contraptions.fluids.actors.SpoutTileEntity;
 import com.simibubi.create.foundation.data.AssetLookup;
 import com.simibubi.create.foundation.data.SharedProperties;
 import com.tterrag.registrate.util.entry.BlockEntityEntry;
 import com.tterrag.registrate.util.entry.BlockEntry;
-import dev.ghen.thirst.content.registry.ItemInit;
 import net.minecraft.client.renderer.RenderType;
 
-import static com.simibubi.create.AllTags.pickaxeOnly;
 import static com.simibubi.create.foundation.data.ModelGen.customItemModel;
 
 public class CreateRegistry
@@ -28,7 +22,6 @@ public class CreateRegistry
         SAND_FILTER_BLOCK = Create.REGISTRATE.block("sand_filter", SandFilterBlock::new)
                 .initialProperties(SharedProperties::copperMetal)
                 .blockstate((ctx, prov) -> prov.simpleBlock(ctx.getEntry(), AssetLookup.partialBaseModel(ctx, prov)))
-                .addLayer(() -> RenderType::cutoutMipped)
                 .item(AssemblyOperatorBlockItem::new)
                 .transform(customItemModel())
                 .register();

--- a/src/main/resources/assets/create/models/block/sand_filter.json
+++ b/src/main/resources/assets/create/models/block/sand_filter.json
@@ -1,6 +1,7 @@
 {
 	"credit": "Made with Blockbench",
 	"parent": "block/block",
+	"render_type": "cutout",
 	"textures": {
 		"0": "create:block/sand_filter",
 		"particle": "create:block/sand_filter"


### PR DESCRIPTION
Was preparing to update the mod for Create 0.5.1, and ran into this error.

Probably won't proceed to update though because it looks like the Create mixins you had are not useful anymore, I don't understand Create