### PR TITLE
fix: guard null NBT in cooking recipe purity check

### DIFF
--- a/src/main/java/dev/ghen/thirst/foundation/mixin/MixinAbstractCookingRecipe.java
+++ b/src/main/java/dev/ghen/thirst/foundation/mixin/MixinAbstractCookingRecipe.java
@@ -13,7 +13,8 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 public class MixinAbstractCookingRecipe {
     @ModifyArg(method = "matches", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/crafting/Ingredient;test(Lnet/minecraft/world/item/ItemStack;)Z"))
     public ItemStack matches(ItemStack itemStack){
-        if(WaterPurity.isWaterFilledContainer(itemStack) && !itemStack.getTag().contains("Purity")){
+        CompoundTag itemTag = itemStack.getTag();
+        if(WaterPurity.isWaterFilledContainer(itemStack) && (itemTag == null || !itemTag.contains("Purity"))){
             ItemStack matched = itemStack.copy();
             CompoundTag tag = matched.getOrCreateTag();
             tag.putInt("Purity", CommonConfig.DEFAULT_PURITY.get());


### PR DESCRIPTION
## Problem

`AbstractCookingRecipe.matches` crashes with a `NullPointerException` when a
water-filled container that has **no NBT tag** is checked against a cooking
recipe:

```
java.lang.NullPointerException: Cannot invoke
"net.minecraft.nbt.CompoundTag.contains(String)" because the return value of
"net.minecraft.world.item.ItemStack.getTag()" is null
    at AbstractCookingRecipe.matches  {mixin: thirst MixinAbstractCookingRecipe}
```

In `MixinAbstractCookingRecipe`:

```java
if(WaterPurity.isWaterFilledContainer(itemStack) && !itemStack.getTag().contains("Purity")){
```

`ItemStack.getTag()` returns `null` for any item without NBT, so
`.contains("Purity")` dereferences null and throws.

This is easy to hit in modpacks: a water container with no tag (e.g. a
Thirst Canteen) placed into a modded furnace that rescans every cooking
recipe (Iron Furnaces + FastSuite) triggers the matcher and crashes the
integrated/dedicated server with a `Ticking block entity` error. The block
entity is then saved holding that item, so the world **crash-loops on load**.

## Fix

Read the tag once and treat a missing tag as "Purity absent" — which is
correct, since a tagless stack cannot already carry a `Purity` value, so the
default purity should still be applied:

```java
CompoundTag itemTag = itemStack.getTag();
if(WaterPurity.isWaterFilledContainer(itemStack) && (itemTag == null || !itemTag.contains("Purity"))){
```

Behavior is unchanged for stacks that already have a tag; only the
previously-crashing null case is handled.
